### PR TITLE
refactor(search): split sites/buildings/POIs into 4 first-class facets

### DIFF
--- a/data/output/openapi.yaml
+++ b/data/output/openapi.yaml
@@ -600,9 +600,10 @@ paths:
         - name: type
           in: query
           description: |-
-            Filter by entry type (e.g. `room`, `building`).
+            Filter by facet (one of `site`, `building`, `room`, `poi`).
 
-            Can be repeated for multiple values.
+            Can be repeated for multiple values. Values outside this set are
+            silently dropped.
           required: false
           schema:
             type: array
@@ -624,10 +625,21 @@ paths:
           required: false
           schema:
             type: boolean
+        - name: limit_sites
+          in: query
+          description: |-
+            Maximum number of sites (campus / site / area) to return.
+
+            Clamped to `0`..`1000`.
+            If this is a problem for you, please open an issue.
+          required: false
+          schema:
+            type: integer
+            minimum: 0
         - name: limit_buildings
           in: query
           description: |-
-            Maximum number of buildings/sites to return.
+            Maximum number of buildings to return.
 
             Clamped to `0`..`1000`.
             If this is a problem for you, please open an issue.
@@ -642,6 +654,17 @@ paths:
 
             Clamped to `0`..`1000`.
             If this is an problem for you, please open an issue.
+          required: false
+          schema:
+            type: integer
+            minimum: 0
+        - name: limit_pois
+          in: query
+          description: |-
+            Maximum number of POIs (points of interest) to return.
+
+            Clamped to `0`..`1000`.
+            If this is a problem for you, please open an issue.
           required: false
           schema:
             type: integer
@@ -2590,8 +2613,10 @@ components:
     ResultFacet:
       type: string
       enum:
-        - sites_buildings
+        - sites
+        - buildings
         - rooms
+        - pois
         - addresses
     ResultsSection:
       type: object

--- a/data/processors/export.py
+++ b/data/processors/export.py
@@ -115,7 +115,7 @@ def export_for_search(data: dict[str, Any]) -> None:
                     "building": "building",
                     "room": "room",
                     "virtual_room": "room",
-                    "poi": "room",
+                    "poi": "poi",
                 }.get(entry["type"]),
                 "operator_name": _de(entry.get("props", {}).get("operator", {}).get("name", None)),
                 "parent_building_names": parent_building_names,

--- a/server/src/external/meilisearch.rs
+++ b/server/src/external/meilisearch.rs
@@ -13,11 +13,17 @@ use crate::routes::search::{FormattingConfig, Limits};
 
 pub(crate) const ENTRIES_INDEX: &str = "entries";
 pub(crate) const FACET_FIELD: &str = "facet";
-pub(crate) const ROOM_FACET: &str = "room";
+pub(crate) const SITE_FACET: &str = "site";
 pub(crate) const BUILDING_FACET: &str = "building";
+pub(crate) const ROOM_FACET: &str = "room";
+pub(crate) const POI_FACET: &str = "poi";
+/// Ordered list of facets the search federates over. Order is the priority
+/// used by the merger when distributing the over-fetched federation budget
+/// across facet caps.
+pub(crate) const FACETS: &[&str] = &[SITE_FACET, BUILDING_FACET, ROOM_FACET, POI_FACET];
 
 /// Federation has no per-facet quota — it merges by `_rankingScore` only. We
-/// over-fetch by this factor so the merger downstream can still fill both
+/// over-fetch by this factor so the merger downstream can still fill all
 /// per-facet caps when one facet dominates the ranking (observed: queries
 /// like `MW1801` returned 14 buildings + 1 room at the natural cap of 15).
 /// Empirical; revisit if facet-starvation shows up in metrics.
@@ -32,6 +38,7 @@ pub struct MSHit {
     pub arch_name: Option<String>,
     pub r#type: String,
     pub type_common_name: String,
+    pub facet: Option<String>,
     pub parent_building_names: Vec<String>,
     parent_keywords: Vec<String>,
     pub campus: Option<String>,
@@ -94,8 +101,12 @@ impl GeoEntryQuery {
     pub async fn execute(self) -> Result<FederatedMultiSearchResponse<MSHit>, Error> {
         let entries = self.client.index(ENTRIES_INDEX);
         let sorting: Vec<&str> = self.sorting.iter().map(String::as_str).collect();
-        let rooms_filter = compose_filter(&facet_eq(ROOM_FACET), &self.user_filter);
-        let buildings_filter = compose_filter(&facet_eq(BUILDING_FACET), &self.user_filter);
+        // One filter per facet, ordered to match `FACETS` so callers can
+        // reason about per-facet behavior consistently.
+        let per_facet_filters: Vec<String> = FACETS
+            .iter()
+            .map(|f| compose_filter(&facet_eq(f), &self.user_filter))
+            .collect();
 
         // Per-query `limit` is rejected by Meilisearch in federated mode; the
         // global cap lives on `federation.limit` instead. `merge_facets` is
@@ -106,12 +117,14 @@ impl GeoEntryQuery {
         facets_by_index.insert(ENTRIES_INDEX.to_string(), vec![FACET_FIELD.to_string()]);
 
         let mut multi = self.client.multi_search();
-        multi.with_search_query(self.facet_query(&entries, &rooms_filter, &sorting));
-        multi.with_search_query(self.facet_query(&entries, &buildings_filter, &sorting));
+        for filter in &per_facet_filters {
+            multi.with_search_query(self.facet_query(&entries, filter, &sorting));
+        }
         multi
             .with_federation(FederationOptions {
                 limit: Some(
-                    (self.limits.buildings_count + self.limits.rooms_count)
+                    self.limits
+                        .per_facet_total()
                         .saturating_mul(FEDERATION_OVERFETCH_FACTOR),
                 ),
                 facets_by_index: Some(facets_by_index),

--- a/server/src/routes/search.rs
+++ b/server/src/routes/search.rs
@@ -80,11 +80,12 @@ pub struct SearchQueryArgs {
     #[schema(example = json!(["wc"]))]
     usage: Vec<String>,
 
-    /// Filter by entry type (e.g. `room`, `building`).
+    /// Filter by facet (one of `site`, `building`, `room`, `poi`).
     ///
-    /// Can be repeated for multiple values.
+    /// Can be repeated for multiple values. Values outside this set are
+    /// silently dropped.
     #[serde(rename = "type", default)]
-    #[schema(example = json!(["room"]))]
+    #[schema(example = json!(["site", "room"]))]
     filter_type: Vec<String>,
 
     /// Sort results by distance to a coordinate (`lat,lon`).
@@ -97,7 +98,14 @@ pub struct SearchQueryArgs {
     /// Only activate this when you really need it.
     search_addresses: Option<bool>,
 
-    /// Maximum number of buildings/sites to return.
+    /// Maximum number of sites (campus / site / area) to return.
+    ///
+    /// Clamped to `0`..`1000`.
+    /// If this is a problem for you, please open an issue.
+    #[schema(default = 5, maximum = 1000, minimum = 0)]
+    limit_sites: Option<usize>,
+
+    /// Maximum number of buildings to return.
     ///
     /// Clamped to `0`..`1000`.
     /// If this is a problem for you, please open an issue.
@@ -110,6 +118,13 @@ pub struct SearchQueryArgs {
     /// If this is an problem for you, please open an issue.
     #[schema(default = 10, maximum = 1000, minimum = 0)]
     limit_rooms: Option<usize>,
+
+    /// Maximum number of POIs (points of interest) to return.
+    ///
+    /// Clamped to `0`..`1000`.
+    /// If this is a problem for you, please open an issue.
+    #[schema(default = 5, maximum = 1000, minimum = 0)]
+    limit_pois: Option<usize>,
 
     /// Maximum number of results to return.
     ///
@@ -195,14 +210,20 @@ impl Debug for SearchResponse {
         base.field("time_ms", &self.time_ms);
         for section in self.sections.iter() {
             match section.facet {
-                ResultFacet::SitesBuildings => {
-                    base.field("sites_buildings", section);
+                ResultFacet::Sites => {
+                    base.field("sites", section);
+                }
+                ResultFacet::Buildings => {
+                    base.field("buildings", section);
                 }
                 ResultFacet::Rooms => {
                     base.field("rooms", section);
                 }
+                ResultFacet::Pois => {
+                    base.field("pois", section);
+                }
                 ResultFacet::Addresses => {
-                    base.field("sites_buildings", section);
+                    base.field("addresses", section);
                 }
             }
         }
@@ -213,16 +234,30 @@ impl Debug for SearchResponse {
 /// Limit per facet
 #[derive(Clone, Eq, PartialEq, Hash)]
 pub struct Limits {
+    pub sites_count: usize,
     pub buildings_count: usize,
     pub rooms_count: usize,
+    pub pois_count: usize,
     pub total_count: usize,
+}
+
+impl Limits {
+    /// Sum of per-facet caps. Used to size the federation budget upstream.
+    pub fn per_facet_total(&self) -> usize {
+        self.sites_count
+            .saturating_add(self.buildings_count)
+            .saturating_add(self.rooms_count)
+            .saturating_add(self.pois_count)
+    }
 }
 
 impl Debug for Limits {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("Limits")
-            .field("building", &self.buildings_count)
+            .field("sites", &self.sites_count)
+            .field("buildings", &self.buildings_count)
             .field("rooms", &self.rooms_count)
+            .field("pois", &self.pois_count)
             .field("total", &self.total_count)
             .finish()
     }
@@ -232,8 +267,10 @@ impl Default for Limits {
     fn default() -> Self {
         Self {
             total_count: 10,
+            sites_count: 5,
             buildings_count: 5,
             rooms_count: 10,
+            pois_count: 5,
         }
     }
 }
@@ -242,6 +279,11 @@ impl From<&SearchQueryArgs> for Limits {
     fn from(args: &SearchQueryArgs) -> Self {
         let total_count = args.limit_all.unwrap_or(10).clamp(0, 1_000);
         Self {
+            sites_count: args
+                .limit_sites
+                .unwrap_or(5)
+                .clamp(0, 1_000)
+                .min(total_count),
             buildings_count: args
                 .limit_buildings
                 .unwrap_or(5)
@@ -250,6 +292,11 @@ impl From<&SearchQueryArgs> for Limits {
             rooms_count: args
                 .limit_rooms
                 .unwrap_or(10)
+                .clamp(0, 1_000)
+                .min(total_count),
+            pois_count: args
+                .limit_pois
+                .unwrap_or(5)
                 .clamp(0, 1_000)
                 .min(total_count),
             total_count,
@@ -368,9 +415,25 @@ fn build_meilisearch_filter(
         ));
     }
     if !filter_type.is_empty() {
-        let types: Vec<String> = filter_type.iter().map(|s| slugify(s)).collect();
-        let types_debug: Vec<&str> = types.iter().map(String::as_str).collect();
-        filters.push(format!("(type IN {types_debug:?})"));
+        // `?type=` semantically filters by *facet* (site, building, room, poi).
+        // Values outside this allowlist are dropped silently.
+        let facets: Vec<String> = filter_type
+            .iter()
+            .map(|s| slugify(s))
+            .filter(|s| {
+                matches!(
+                    s.as_str(),
+                    crate::external::meilisearch::SITE_FACET
+                        | crate::external::meilisearch::BUILDING_FACET
+                        | crate::external::meilisearch::ROOM_FACET
+                        | crate::external::meilisearch::POI_FACET
+                )
+            })
+            .collect();
+        if !facets.is_empty() {
+            let facets_debug: Vec<&str> = facets.iter().map(String::as_str).collect();
+            filters.push(format!("(facet IN {facets_debug:?})"));
+        }
     }
     if !usage.is_empty() {
         let usages: Vec<String> = usage.iter().map(|s| slugify(s)).collect();
@@ -458,7 +521,7 @@ pub async fn search_handler(data: web::Data<AppData>, args: SearchQueryArgs) -> 
 
     debug!(?results_sections, "searching returned");
 
-    if results_sections.len() > 3 {
+    if results_sections.len() > 5 {
         error!(
             returned_section_cnt = results_sections.len(),
             "searching did not return expected the amount of sections it expected",
@@ -530,19 +593,25 @@ mod tests {
 
     fn assert_limits_invariants(limits: Limits) {
         assert!(limits.total_count <= 1_000);
-        assert!(limits.rooms_count <= 1_000);
+        assert!(limits.sites_count <= 1_000);
         assert!(limits.buildings_count <= 1_000);
+        assert!(limits.rooms_count <= 1_000);
+        assert!(limits.pois_count <= 1_000);
 
-        assert!(limits.rooms_count <= limits.total_count);
+        assert!(limits.sites_count <= limits.total_count);
         assert!(limits.buildings_count <= limits.total_count);
+        assert!(limits.rooms_count <= limits.total_count);
+        assert!(limits.pois_count <= limits.total_count);
     }
 
     #[test]
     fn limits_default_values_are_sane() {
         let limits = Limits::default();
         assert_eq!(limits.total_count, 10);
-        assert_eq!(limits.rooms_count, 10);
+        assert_eq!(limits.sites_count, 5);
         assert_eq!(limits.buildings_count, 5);
+        assert_eq!(limits.rooms_count, 10);
+        assert_eq!(limits.pois_count, 5);
         assert_limits_invariants(limits);
     }
 
@@ -550,15 +619,19 @@ mod tests {
     fn limits_are_clamped_to_global_max() {
         let input = SearchQueryArgs {
             limit_all: Some(usize::MAX),
+            limit_sites: Some(usize::MAX),
             limit_rooms: Some(usize::MAX),
             limit_buildings: Some(usize::MAX),
+            limit_pois: Some(usize::MAX),
             ..Default::default()
         };
         let limits = Limits::from(&input);
 
         assert_eq!(limits.total_count, 1_000);
+        assert_eq!(limits.sites_count, 1_000);
         assert_eq!(limits.rooms_count, 1_000);
         assert_eq!(limits.buildings_count, 1_000);
+        assert_eq!(limits.pois_count, 1_000);
         assert_limits_invariants(limits);
     }
 
@@ -566,15 +639,19 @@ mod tests {
     fn limits_total_constrains_per_facet_limits() {
         let input = SearchQueryArgs {
             limit_all: Some(10),
+            limit_sites: Some(100),
             limit_rooms: Some(100),
             limit_buildings: Some(100),
+            limit_pois: Some(100),
             ..Default::default()
         };
         let limits = Limits::from(&input);
 
         assert_eq!(limits.total_count, 10);
+        assert_eq!(limits.sites_count, 10);
         assert_eq!(limits.rooms_count, 10);
         assert_eq!(limits.buildings_count, 10);
+        assert_eq!(limits.pois_count, 10);
         assert_limits_invariants(limits);
     }
 
@@ -582,16 +659,32 @@ mod tests {
     fn limits_zero_is_allowed_and_keeps_invariants() {
         let input = SearchQueryArgs {
             limit_all: Some(0),
+            limit_sites: Some(0),
             limit_rooms: Some(0),
             limit_buildings: Some(0),
+            limit_pois: Some(0),
             ..Default::default()
         };
         let limits = Limits::from(&input);
 
         assert_eq!(limits.total_count, 0);
+        assert_eq!(limits.sites_count, 0);
         assert_eq!(limits.rooms_count, 0);
         assert_eq!(limits.buildings_count, 0);
+        assert_eq!(limits.pois_count, 0);
         assert_limits_invariants(limits);
+    }
+
+    #[test]
+    fn limits_per_facet_total_sums_all_facets() {
+        let limits = Limits {
+            sites_count: 1,
+            buildings_count: 2,
+            rooms_count: 3,
+            pois_count: 4,
+            total_count: 100,
+        };
+        assert_eq!(limits.per_facet_total(), 10);
     }
 
     #[test]
@@ -702,7 +795,7 @@ mod tests {
     #[test]
     fn filter_type_only() {
         let filter = build_meilisearch_filter(&[], &[], &["room".to_string()]);
-        assert!(filter.contains("type"));
+        assert!(filter.contains("facet"));
         assert!(filter.contains("room"));
     }
 
@@ -727,9 +820,33 @@ mod tests {
     }
 
     #[test]
-    fn filter_preserves_underscores_in_parent_values() {
+    fn filter_type_drops_unknown_facets() {
+        // `joined_building` is no longer a valid facet (it's a `type`); it
+        // must be dropped so we don't leak invalid filters into Meilisearch.
         let filter = build_meilisearch_filter(&[], &[], &["joined_building".to_string()]);
-        assert!(filter.contains("joined_building"));
+        assert_eq!(filter, "");
+    }
+
+    #[test]
+    fn filter_type_keeps_only_known_facets() {
+        let filter = build_meilisearch_filter(
+            &[],
+            &[],
+            &[
+                "site".to_string(),
+                "campus".to_string(),
+                "poi".to_string(),
+                "room".to_string(),
+                "virtual_room".to_string(),
+            ],
+        );
+        assert!(filter.contains("facet"));
+        assert!(filter.contains("site"));
+        assert!(filter.contains("poi"));
+        assert!(filter.contains("room"));
+        // dropped: not in the facet allowlist
+        assert!(!filter.contains("campus"));
+        assert!(!filter.contains("virtual_room"));
     }
 
     #[test]

--- a/server/src/search_executor/merger.rs
+++ b/server/src/search_executor/merger.rs
@@ -3,90 +3,157 @@ use std::collections::HashMap;
 use meilisearch_sdk::search::SearchResult;
 
 use super::ResultFacet;
-use crate::external::meilisearch::{BUILDING_FACET, FACET_FIELD, MSHit, ROOM_FACET};
+use crate::external::meilisearch::{
+    BUILDING_FACET, FACET_FIELD, MSHit, POI_FACET, ROOM_FACET, SITE_FACET,
+};
 use crate::routes::search::Limits;
+
+pub(super) struct MergedSections {
+    pub(super) sites: super::ResultsSection,
+    pub(super) buildings: super::ResultsSection,
+    pub(super) rooms: super::ResultsSection,
+    pub(super) pois: super::ResultsSection,
+}
 
 #[tracing::instrument(skip(hits, facet_distribution))]
 pub(super) fn merge_search_results(
     limits: &Limits,
     hits: &[SearchResult<MSHit>],
     facet_distribution: Option<&HashMap<String, HashMap<String, usize>>>,
-) -> (super::ResultsSection, super::ResultsSection) {
-    let (buildings_total, rooms_total) = facet_totals(facet_distribution);
+) -> MergedSections {
+    let totals = facet_totals(facet_distribution);
 
-    let mut section_buildings = super::ResultsSection {
-        facet: ResultFacet::SitesBuildings,
-        entries: Vec::new(),
-        n_visible: 0,
-        estimated_total_hits: buildings_total,
-    };
-    let mut section_rooms = super::ResultsSection {
-        facet: ResultFacet::Rooms,
-        entries: Vec::new(),
-        n_visible: 0,
-        estimated_total_hits: rooms_total,
-    };
+    let mut sites = empty_section(ResultFacet::Sites, totals.sites);
+    let mut buildings = empty_section(ResultFacet::Buildings, totals.buildings);
+    let mut rooms = empty_section(ResultFacet::Rooms, totals.rooms);
+    let mut pois = empty_section(ResultFacet::Pois, totals.pois);
 
+    // Visible counts of higher-priority facets are frozen the moment a
+    // lower-priority facet's first hit appears in the ranking. This preserves
+    // the original two-section behavior (a lower-ranked room would not
+    // retroactively expand the default visible buildings count) and
+    // generalizes it to four facets: sites > buildings > rooms > pois.
     for hit in hits {
-        let current_buildings_cnt = if section_buildings.n_visible == 0 {
-            section_buildings.entries.len()
-        } else {
-            section_buildings.n_visible
-        };
-        if section_rooms.entries.len() + current_buildings_cnt >= limits.total_count {
+        let cap = active_count(&sites) + active_count(&buildings) + active_count(&rooms) + active_count(&pois);
+        if cap >= limits.total_count {
             break;
         }
 
-        match hit.result.r#type.as_str() {
-            "campus" | "site" | "area" | "building" | "joined_building"
-                if section_buildings.entries.len() < limits.buildings_count =>
-            {
-                let result = hit.result.clone();
-                let name = extract_formatted_name(hit).unwrap_or_else(|| result.name.clone());
-                section_buildings.entries.push(super::ResultEntry {
-                    id: result.room_code.clone(),
-                    r#type: result.r#type.clone(),
-                    subtext: result.type_common_name.clone(),
-                    hit: result,
-                    name,
-                    subtext_bold: None,
-                    parsed_id: None,
-                });
+        match hit.result.facet.as_deref() {
+            Some(SITE_FACET) if sites.entries.len() < limits.sites_count => {
+                sites.entries.push(make_building_like_entry(hit));
             }
-            "room" | "virtual_room" | "poi" if section_rooms.entries.len() < limits.rooms_count => {
-                let result = hit.result.clone();
-                let name = extract_formatted_name(hit).unwrap_or_else(|| result.name.clone());
-                section_rooms.entries.push(super::ResultEntry {
-                    id: result.room_code.clone(),
-                    r#type: result.r#type.clone(),
-                    subtext_bold: Some(result.arch_name.clone().unwrap_or_default()),
-                    hit: result,
-                    name,
-                    ..super::ResultEntry::default()
-                });
-
-                // The first room in the results 'freezes' the number of visible
-                // buildings: a hit appearing after rooms in the ranking should
-                // not retroactively expand the default building section.
-                if section_buildings.n_visible == 0 && section_rooms.entries.len() == 1 {
-                    section_buildings.n_visible = section_buildings.entries.len();
-                }
+            Some(BUILDING_FACET) if buildings.entries.len() < limits.buildings_count => {
+                freeze_if_first(&mut sites);
+                buildings.entries.push(make_building_like_entry(hit));
+            }
+            Some(ROOM_FACET) if rooms.entries.len() < limits.rooms_count => {
+                freeze_if_first(&mut sites);
+                freeze_if_first(&mut buildings);
+                rooms.entries.push(make_room_like_entry(hit));
+            }
+            Some(POI_FACET) if pois.entries.len() < limits.pois_count => {
+                freeze_if_first(&mut sites);
+                freeze_if_first(&mut buildings);
+                freeze_if_first(&mut rooms);
+                pois.entries.push(make_room_like_entry(hit));
             }
             _ => {}
         };
     }
-    section_rooms.n_visible = section_rooms.entries.len();
 
-    (section_buildings, section_rooms)
+    // Sections that never got their visible count frozen show all collected
+    // entries by default.
+    finalize_visible(&mut sites);
+    finalize_visible(&mut buildings);
+    finalize_visible(&mut rooms);
+    finalize_visible(&mut pois);
+
+    MergedSections {
+        sites,
+        buildings,
+        rooms,
+        pois,
+    }
 }
 
-fn facet_totals(distribution: Option<&HashMap<String, HashMap<String, usize>>>) -> (usize, usize) {
+/// Freeze the visible count of a higher-priority section the first time a
+/// lower-priority hit lands. No-op if the section is empty (it stays at 0)
+/// or already frozen.
+fn freeze_if_first(section: &mut super::ResultsSection) {
+    if section.n_visible == 0 && !section.entries.is_empty() {
+        section.n_visible = section.entries.len();
+    }
+}
+
+fn finalize_visible(section: &mut super::ResultsSection) {
+    if section.n_visible == 0 {
+        section.n_visible = section.entries.len();
+    }
+}
+
+fn active_count(section: &super::ResultsSection) -> usize {
+    if section.n_visible == 0 {
+        section.entries.len()
+    } else {
+        section.n_visible
+    }
+}
+
+fn empty_section(facet: ResultFacet, estimated_total_hits: usize) -> super::ResultsSection {
+    super::ResultsSection {
+        facet,
+        entries: Vec::new(),
+        n_visible: 0,
+        estimated_total_hits,
+    }
+}
+
+fn make_building_like_entry(hit: &SearchResult<MSHit>) -> super::ResultEntry {
+    let result = hit.result.clone();
+    let name = extract_formatted_name(hit).unwrap_or_else(|| result.name.clone());
+    super::ResultEntry {
+        id: result.room_code.clone(),
+        r#type: result.r#type.clone(),
+        subtext: result.type_common_name.clone(),
+        hit: result,
+        name,
+        subtext_bold: None,
+        parsed_id: None,
+    }
+}
+
+fn make_room_like_entry(hit: &SearchResult<MSHit>) -> super::ResultEntry {
+    let result = hit.result.clone();
+    let name = extract_formatted_name(hit).unwrap_or_else(|| result.name.clone());
+    super::ResultEntry {
+        id: result.room_code.clone(),
+        r#type: result.r#type.clone(),
+        subtext_bold: Some(result.arch_name.clone().unwrap_or_default()),
+        hit: result,
+        name,
+        ..super::ResultEntry::default()
+    }
+}
+
+#[derive(Default)]
+struct FacetTotals {
+    sites: usize,
+    buildings: usize,
+    rooms: usize,
+    pois: usize,
+}
+
+fn facet_totals(distribution: Option<&HashMap<String, HashMap<String, usize>>>) -> FacetTotals {
     let Some(facet) = distribution.and_then(|d| d.get(FACET_FIELD)) else {
-        return (0, 0);
+        return FacetTotals::default();
     };
-    let buildings = facet.get(BUILDING_FACET).copied().unwrap_or(0);
-    let rooms = facet.get(ROOM_FACET).copied().unwrap_or(0);
-    (buildings, rooms)
+    FacetTotals {
+        sites: facet.get(SITE_FACET).copied().unwrap_or(0),
+        buildings: facet.get(BUILDING_FACET).copied().unwrap_or(0),
+        rooms: facet.get(ROOM_FACET).copied().unwrap_or(0),
+        pois: facet.get(POI_FACET).copied().unwrap_or(0),
+    }
 }
 
 fn extract_formatted_name(hit: &SearchResult<MSHit>) -> Option<String> {

--- a/server/src/search_executor/mod.rs
+++ b/server/src/search_executor/mod.rs
@@ -15,11 +15,13 @@ mod lexer;
 mod merger;
 mod parser;
 
-#[derive(Serialize, Clone, Copy, utoipa::ToSchema)]
+#[derive(Serialize, Clone, Copy, utoipa::ToSchema, Debug, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum ResultFacet {
-    SitesBuildings,
+    Sites,
+    Buildings,
     Rooms,
+    Pois,
     Addresses,
 }
 
@@ -161,7 +163,12 @@ pub async fn do_geoentry_search(
             return LimitedVec(vec![]);
         }
     };
-    let (section_buildings, mut section_rooms) = merger::merge_search_results(
+    let merger::MergedSections {
+        sites: section_sites,
+        buildings: section_buildings,
+        rooms: mut section_rooms,
+        pois: section_pois,
+    } = merger::merge_search_results(
         &limits,
         &response.hits,
         response.facet_distribution.as_ref(),
@@ -172,10 +179,14 @@ pub async fn do_geoentry_search(
         .iter_mut()
         .for_each(|r| visitor.visit(r));
 
-    match section_buildings.n_visible {
-        0 => LimitedVec(vec![section_rooms, section_buildings]),
-        _ => LimitedVec(vec![section_buildings, section_rooms]),
-    }
+    // Order: non-empty facets first, in priority order (sites > buildings >
+    // rooms > pois). Empty sections still trail at the end so the caller can
+    // observe `estimated_total_hits` if it cares (mirrors the previous
+    // two-section behavior where the empty section was kept in the response).
+    let sections = [section_sites, section_buildings, section_rooms, section_pois];
+    let (non_empty, empty): (Vec<_>, Vec<_>) =
+        sections.into_iter().partition(|s| s.n_visible != 0);
+    LimitedVec(non_empty.into_iter().chain(empty).collect())
 }
 
 #[cfg(test)]

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__both_flags_work_together.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__both_flags_work_together.snap
@@ -1,9 +1,17 @@
 ---
-source: src/search_executor/mod.rs
+source: server/src/search_executor/mod.rs
 description: "Query: N-1406"
 expression: results.0
 info: "parsed_id=roomfinder,cropping=full"
 ---
+- facet: buildings
+  entries:
+    - id: "9201"
+      type: building
+      name: "TUM FZ Friedrich \u0019N\u0017. Schwarz Berchtesgaden"
+      subtext: Gebäude
+  n_visible: 1
+  estimatedTotalHits: "[estimatedTotalHits]"
 - facet: rooms
   entries:
     - id: 0104.U1.406
@@ -62,11 +70,11 @@ info: "parsed_id=roomfinder,cropping=full"
       parsed_id: EG-06@9201
   n_visible: 9
   estimatedTotalHits: "[estimatedTotalHits]"
-- facet: sites_buildings
-  entries:
-    - id: "9201"
-      type: building
-      name: "TUM FZ Friedrich \u0019N\u0017. Schwarz Berchtesgaden"
-      subtext: Gebäude
+- facet: sites
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: pois
+  entries: []
   n_visible: 0
   estimatedTotalHits: "[estimatedTotalHits]"

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__building_formats.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__building_formats.snap
@@ -1,9 +1,33 @@
 ---
-source: src/search_executor/mod.rs
+source: server/src/search_executor/mod.rs
 description: "Query: MW1801"
 expression: results_prefixed.0
 info: parsed_id=prefixed
 ---
+- facet: buildings
+  entries:
+    - id: mw
+      type: joined_building
+      name: "Maschinenwesen (\u0019MW\u0017)"
+      subtext: Gebäudekomplex
+    - id: "5506"
+      type: building
+      name: "Gebäudeteil 6, Institut für Luft- und Raumfahrt"
+      subtext: Gebäudeteil
+    - id: "5501"
+      type: building
+      name: "Gebäudeteil 1, Institut für Mechatronik"
+      subtext: Gebäudeteil
+    - id: "5502"
+      type: building
+      name: "Gebäudeteil 2, Institut für Werkstoffe und Verarbeitung"
+      subtext: Gebäudeteil
+    - id: "5504"
+      type: building
+      name: "Gebäudeteil 4, Institut für Verfahrenstechnik"
+      subtext: Gebäudeteil
+  n_visible: 5
+  estimatedTotalHits: "[estimatedTotalHits]"
 - facet: rooms
   entries:
     - id: 5508.02.801
@@ -33,27 +57,11 @@ info: parsed_id=prefixed
       subtext_bold: 0350@5503
   n_visible: 5
   estimatedTotalHits: "[estimatedTotalHits]"
-- facet: sites_buildings
-  entries:
-    - id: mw
-      type: joined_building
-      name: "Maschinenwesen (\u0019MW\u0017)"
-      subtext: Gebäudekomplex
-    - id: "5506"
-      type: building
-      name: "Gebäudeteil 6, Institut für Luft- und Raumfahrt"
-      subtext: Gebäudeteil
-    - id: "5501"
-      type: building
-      name: "Gebäudeteil 1, Institut für Mechatronik"
-      subtext: Gebäudeteil
-    - id: "5502"
-      type: building
-      name: "Gebäudeteil 2, Institut für Werkstoffe und Verarbeitung"
-      subtext: Gebäudeteil
-    - id: "5504"
-      type: building
-      name: "Gebäudeteil 4, Institut für Verfahrenstechnik"
-      subtext: Gebäudeteil
+- facet: sites
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: pois
+  entries: []
   n_visible: 0
   estimatedTotalHits: "[estimatedTotalHits]"

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__cropping_behavior_for_1010.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__cropping_behavior_for_1010.snap
@@ -1,5 +1,5 @@
 ---
-source: src/search_executor/mod.rs
+source: server/src/search_executor/mod.rs
 description: "Query: 1010 znn"
 expression: results_cropped.0
 info: cropping=crop
@@ -64,7 +64,15 @@ info: cropping=crop
       parsed_id: "\u00191010\u0017 Zentrum…tion (ZEI)"
   n_visible: 10
   estimatedTotalHits: "[estimatedTotalHits]"
-- facet: sites_buildings
+- facet: sites
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: buildings
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: pois
   entries: []
   n_visible: 0
   estimatedTotalHits: "[estimatedTotalHits]"

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__cropping_full_shows_full_building_names.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__cropping_full_shows_full_building_names.snap
@@ -1,9 +1,17 @@
 ---
-source: src/search_executor/mod.rs
+source: server/src/search_executor/mod.rs
 description: "Query: N-1406"
 expression: results_cropping.0
 info: cropping=crop
 ---
+- facet: buildings
+  entries:
+    - id: "9201"
+      type: building
+      name: "TUM FZ Friedrich \u0019N\u0017. Schwarz Berchtesgaden"
+      subtext: Gebäude
+  n_visible: 1
+  estimatedTotalHits: "[estimatedTotalHits]"
 - facet: rooms
   entries:
     - id: 0104.U1.406
@@ -54,11 +62,11 @@ info: cropping=crop
       subtext_bold: EG-06@9201
   n_visible: 9
   estimatedTotalHits: "[estimatedTotalHits]"
-- facet: sites_buildings
-  entries:
-    - id: "9201"
-      type: building
-      name: "TUM FZ Friedrich \u0019N\u0017. Schwarz Berchtesgaden"
-      subtext: Gebäude
+- facet: sites
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: pois
+  entries: []
   n_visible: 0
   estimatedTotalHits: "[estimatedTotalHits]"

--- a/server/src/search_executor/snapshots/navigatum_server__search_executor__test__custom_highlighting_with_formatting.snap
+++ b/server/src/search_executor/snapshots/navigatum_server__search_executor__test__custom_highlighting_with_formatting.snap
@@ -1,9 +1,33 @@
 ---
-source: src/search_executor/mod.rs
+source: server/src/search_executor/mod.rs
 description: "Query: MW1801"
 expression: results.0
 info: highlighting=<em>
 ---
+- facet: buildings
+  entries:
+    - id: mw
+      type: joined_building
+      name: Maschinenwesen (<em>MW</em>)
+      subtext: Gebäudekomplex
+    - id: "5506"
+      type: building
+      name: "Gebäudeteil 6, Institut für Luft- und Raumfahrt"
+      subtext: Gebäudeteil
+    - id: "5501"
+      type: building
+      name: "Gebäudeteil 1, Institut für Mechatronik"
+      subtext: Gebäudeteil
+    - id: "5502"
+      type: building
+      name: "Gebäudeteil 2, Institut für Werkstoffe und Verarbeitung"
+      subtext: Gebäudeteil
+    - id: "5504"
+      type: building
+      name: "Gebäudeteil 4, Institut für Verfahrenstechnik"
+      subtext: Gebäudeteil
+  n_visible: 5
+  estimatedTotalHits: "[estimatedTotalHits]"
 - facet: rooms
   entries:
     - id: 5508.02.801
@@ -33,27 +57,11 @@ info: highlighting=<em>
       subtext_bold: 0350@5503
   n_visible: 5
   estimatedTotalHits: "[estimatedTotalHits]"
-- facet: sites_buildings
-  entries:
-    - id: mw
-      type: joined_building
-      name: Maschinenwesen (<em>MW</em>)
-      subtext: Gebäudekomplex
-    - id: "5506"
-      type: building
-      name: "Gebäudeteil 6, Institut für Luft- und Raumfahrt"
-      subtext: Gebäudeteil
-    - id: "5501"
-      type: building
-      name: "Gebäudeteil 1, Institut für Mechatronik"
-      subtext: Gebäudeteil
-    - id: "5502"
-      type: building
-      name: "Gebäudeteil 2, Institut für Werkstoffe und Verarbeitung"
-      subtext: Gebäudeteil
-    - id: "5504"
-      type: building
-      name: "Gebäudeteil 4, Institut für Verfahrenstechnik"
-      subtext: Gebäudeteil
+- facet: sites
+  entries: []
+  n_visible: 0
+  estimatedTotalHits: "[estimatedTotalHits]"
+- facet: pois
+  entries: []
   n_visible: 0
   estimatedTotalHits: "[estimatedTotalHits]"

--- a/webclient/app/api_types/index.ts
+++ b/webclient/app/api_types/index.ts
@@ -1282,7 +1282,7 @@ export type components = {
       readonly type: string;
     };
     /** @enum {string} */
-    readonly ResultFacet: "sites_buildings" | "rooms" | "addresses";
+    readonly ResultFacet: "sites" | "buildings" | "rooms" | "pois" | "addresses";
     readonly ResultsSection: {
       readonly entries: readonly components["schemas"]["ResultEntry"][];
       /**
@@ -2124,9 +2124,10 @@ export type operations = {
          */
         usage?: readonly string[];
         /**
-         * @description Filter by entry type (e.g. `room`, `building`).
+         * @description Filter by facet (one of `site`, `building`, `room`, `poi`).
          *
-         * Can be repeated for multiple values.
+         * Can be repeated for multiple values. Values outside this set are
+         * silently dropped.
          */
         type?: readonly string[];
         /** @description Sort results by distance to a coordinate (`lat,lon`). */
@@ -2139,7 +2140,14 @@ export type operations = {
          */
         search_addresses?: boolean;
         /**
-         * @description Maximum number of buildings/sites to return.
+         * @description Maximum number of sites (campus / site / area) to return.
+         *
+         * Clamped to `0`..`1000`.
+         * If this is a problem for you, please open an issue.
+         */
+        limit_sites?: number;
+        /**
+         * @description Maximum number of buildings to return.
          *
          * Clamped to `0`..`1000`.
          * If this is a problem for you, please open an issue.
@@ -2152,6 +2160,13 @@ export type operations = {
          * If this is an problem for you, please open an issue.
          */
         limit_rooms?: number;
+        /**
+         * @description Maximum number of POIs (points of interest) to return.
+         *
+         * Clamped to `0`..`1000`.
+         * If this is a problem for you, please open an issue.
+         */
+        limit_pois?: number;
         /**
          * @description Maximum number of results to return.
          *

--- a/webclient/app/components/AppSearchBar.vue
+++ b/webclient/app/components/AppSearchBar.vue
@@ -18,21 +18,20 @@ const keep_focus = ref(false);
 const interacting_with_panel = ref(false);
 const query = ref(Array.isArray(route.query.q) ? (route.query.q[0] ?? "") : (route.query.q ?? ""));
 const highlighted = ref<number | undefined>(undefined);
-const sites_buildings_expanded = ref<boolean>(false);
+// Per-facet expand state. Sites/buildings/rooms can freeze with
+// `n_visible < entries.length` when a lower-priority facet appears; the
+// "show hidden" button on each such section toggles its slot here.
+const expandedFacets = ref<Set<string>>(new Set());
 
 const visibleElements = computed<string[]>(() => {
   if (!data.value) return [] as string[];
 
   const visible: string[] = [] as string[];
   for (const section of data.value.sections) {
-    if (section.facet === "sites_buildings") {
-      const max_sites_buildings = sites_buildings_expanded.value
-        ? Number.POSITIVE_INFINITY
-        : section.n_visible;
-      visible.push(...section.entries.slice(0, max_sites_buildings).map((e) => e.id));
-    } else {
-      visible.push(...section.entries.map((e) => e.id));
-    }
+    const cap = expandedFacets.value.has(section.facet)
+      ? Number.POSITIVE_INFINITY
+      : section.n_visible;
+    visible.push(...section.entries.slice(0, cap).map((e) => e.id));
   }
   return visible;
 });
@@ -222,7 +221,7 @@ const { data, error } = useFetch<SearchResponse>(url, {
 
           <template v-for="(e, i) in s.entries" :key="e.id">
             <SearchResultItemLink
-              v-if="i < s.n_visible"
+              v-if="expandedFacets.has(s.facet) || i < s.n_visible"
               :highlighted="e.id === visibleElements[highlighted ?? -1]"
               :item="e"
               @click="searchBarFocused = false"
@@ -232,11 +231,11 @@ const { data, error } = useFetch<SearchResponse>(url, {
           </template>
           <li class="-mt-2">
             <Btn
-              v-if="s.facet === 'sites_buildings' && !sites_buildings_expanded && s.n_visible < s.entries.length"
+              v-if="!expandedFacets.has(s.facet) && s.n_visible < s.entries.length"
               variant="linkButton"
               size="sm"
               @mousedown="keep_focus = true"
-              @click="sites_buildings_expanded = true"
+              @click="expandedFacets = new Set([...expandedFacets, s.facet])"
             >
               {{ t("show_hidden", s.entries.length - s.n_visible) }}
             </Btn>
@@ -261,8 +260,11 @@ de:
     action: Go
   show_hidden: +{count} ausgeblendet
   sections:
-    sites_buildings: Gebäude / Standorte
+    sites: Standorte
+    buildings: Gebäude
     rooms: Räume
+    pois: POIs
+    addresses: Adressen
   results: 1 Ergebnis | {count} Ergebnisse
   approx_results: ca. {count} Ergebnisse
 en:
@@ -273,8 +275,11 @@ en:
     action: Go
   show_hidden: +{count} hidden
   sections:
-    sites_buildings: Buildings / Sites
+    sites: Sites
+    buildings: Buildings
     rooms: Rooms
+    pois: POIs
+    addresses: Addresses
   results: 1 result | {count} results
   approx_results: approx. {count} results
 </i18n>

--- a/webclient/app/components/NavigationSearchBar.vue
+++ b/webclient/app/components/NavigationSearchBar.vue
@@ -61,19 +61,19 @@ const selected = useRouteQuery<string>(props.queryId, "", {
   router,
 });
 const highlighted = ref<number>(0);
-const sites_buildings_expanded = ref<boolean>(false);
+// Per-facet expand state (sites/buildings/rooms can freeze with
+// `n_visible < entries.length`).
+const expandedFacets = ref<Set<string>>(new Set());
 
 const visibleElements = computed<string[]>(() => {
   if (!data.value) return [];
 
   const visible: string[] = [];
   for (const section of data.value.sections) {
-    if (section.facet === "sites_buildings") {
-      const max_sites_buildings = sites_buildings_expanded.value
-        ? Number.POSITIVE_INFINITY
-        : section.n_visible;
-      visible.push(...section.entries.slice(0, max_sites_buildings).map((e) => e.id));
-    } else visible.push(...section.entries.map((e) => e.id));
+    const cap = expandedFacets.value.has(section.facet)
+      ? Number.POSITIVE_INFINITY
+      : section.n_visible;
+    visible.push(...section.entries.slice(0, cap).map((e) => e.id));
   }
   return visible;
 });
@@ -252,7 +252,7 @@ const { data, error } = await useFetch<SearchResponse>(url, {
 
         <template v-for="(e, i) in s.entries" :key="e.id">
           <SearchResultItem
-            v-if="i < s.n_visible"
+            v-if="expandedFacets.has(s.facet) || i < s.n_visible"
             :highlighted="e.id === visibleElements[highlighted ?? -1]"
             :item="e"
             @click="select(e.id)"
@@ -261,10 +261,10 @@ const { data, error } = await useFetch<SearchResponse>(url, {
         </template>
         <li class="-mt-2">
           <Btn
-            v-if="s.facet === 'sites_buildings' && !sites_buildings_expanded && s.n_visible < s.entries.length"
+            v-if="!expandedFacets.has(s.facet) && s.n_visible < s.entries.length"
             variant="linkButton"
             size="sm"
-            @click="sites_buildings_expanded = true"
+            @click="expandedFacets = new Set([...expandedFacets, s.facet])"
           >
             {{ t("show_hidden", s.entries.length - s.n_visible) }}
           </Btn>
@@ -289,8 +289,10 @@ de:
     action: Go
   show_hidden: +{count} ausgeblendet
   sections:
-    sites_buildings: Gebäude / Standorte
+    sites: Standorte
+    buildings: Gebäude
     rooms: Räume
+    pois: POIs
     addresses: Adressen
   results: 1 Ergebnis | {count} Ergebnisse
   approx_results: ca. {count} Ergebnisse
@@ -314,9 +316,11 @@ en:
     action: Go
   show_hidden: +{count} hidden
   sections:
-    sites_buildings: Buildings / Sites
+    sites: Sites
+    buildings: Buildings
     rooms: Rooms
-    addresses: Adresses
+    pois: POIs
+    addresses: Addresses
   results: 1 result | {count} results
   approx_results: approx. {count} results
   gps:

--- a/webclient/app/components/SearchFilterChips.vue
+++ b/webclient/app/components/SearchFilterChips.vue
@@ -12,7 +12,7 @@ import {
 import { useTemplateRef } from "vue";
 import type { components } from "~/api_types";
 import { useKnownUsages } from "~/composables/knownUsages";
-import { type SearchFilters, TYPE_BUCKET_OPTIONS } from "~/composables/searchFilters";
+import { FACET_OPTIONS, type SearchFilters } from "~/composables/searchFilters";
 
 type SearchResponse = components["schemas"]["SearchResponse"];
 
@@ -45,8 +45,10 @@ const {
     const params = new URLSearchParams();
     params.append("q", locationSearch.value);
     params.append("limit_all", "8");
+    params.append("limit_sites", "8");
     params.append("limit_buildings", "8");
     params.append("limit_rooms", "0");
+    params.append("limit_pois", "0");
     params.append("pre_highlight", "<b class='text-blue'>");
     params.append("post_highlight", "</b>");
     return `${runtimeConfig.public.apiURL}/api/search?${params.toString()}`;
@@ -65,8 +67,10 @@ watch(locationSearch, (q) => {
 
 const locationSuggestions = computed<LocationSuggestion[]>(() => {
   if (locationSearch.value.length < 2) return [];
-  const section = locationData.value?.sections.find((s) => s.facet === "sites_buildings");
-  return section?.entries.map((e) => ({ id: e.id, name: e.name, subtext: e.subtext })) ?? [];
+  const sections = locationData.value?.sections ?? [];
+  return sections
+    .filter((s) => s.facet === "sites" || s.facet === "buildings")
+    .flatMap((s) => s.entries.map((e) => ({ id: e.id, name: e.name, subtext: e.subtext })));
 });
 
 const locationLoading = computed(
@@ -155,7 +159,7 @@ function closeLocation() {
       <PopoverPanel
         class="ring-black/5 absolute left-0 z-20 mt-2 w-48 rounded-sm bg-white p-2 shadow-lg ring-1 dark:bg-zinc-100">
         <label
-          v-for="opt in TYPE_BUCKET_OPTIONS"
+          v-for="opt in FACET_OPTIONS"
           :key="opt"
           class="flex cursor-pointer items-center gap-2 rounded-sm px-2 py-1.5 text-sm hover:bg-zinc-100 dark:hover:bg-zinc-200 text-zinc-800"
         >

--- a/webclient/app/components/SearchSectionList.vue
+++ b/webclient/app/components/SearchSectionList.vue
@@ -7,18 +7,29 @@ type SearchResponse = components["schemas"]["SearchResponse"];
 
 const props = defineProps<{
   data: SearchResponse;
+  queryLimitSites: number;
   queryLimitBuildings: number;
   queryLimitRooms: number;
+  queryLimitPois: number;
 }>();
 const { t } = useI18n({ useScope: "local" });
 const route = useRoute();
 const filters = useSearchFilters();
 
+const SITE_BUMP = 20;
+const BUILDING_BUMP = 20;
+const ROOM_BUMP = 50;
+const POI_BUMP = 20;
+
 function viewMoreQuery(facet: string) {
+  // Bump only the facet whose "view more" was clicked; keep the other limits
+  // at their current values so unrelated sections don't grow.
   return {
     q: route.query.q,
-    limit_buildings: facet === "rooms" ? props.queryLimitBuildings : props.queryLimitBuildings + 20,
-    limit_rooms: facet === "rooms" ? props.queryLimitRooms + 50 : props.queryLimitRooms,
+    limit_sites: props.queryLimitSites + (facet === "sites" ? SITE_BUMP : 0),
+    limit_buildings: props.queryLimitBuildings + (facet === "buildings" ? BUILDING_BUMP : 0),
+    limit_rooms: props.queryLimitRooms + (facet === "rooms" ? ROOM_BUMP : 0),
+    limit_pois: props.queryLimitPois + (facet === "pois" ? POI_BUMP : 0),
     ...filters.buildQueryObject(),
   };
 }
@@ -26,7 +37,7 @@ function viewMoreQuery(facet: string) {
 
 <template>
   <div v-for="s in data.sections" :key="s.facet">
-    <section class="flex flex-col gap-2">
+    <section v-if="s.entries.length" class="flex flex-col gap-2">
       <h2 class="text-md text-zinc-500 font-semibold">{{ t(`sections.${s.facet}`) }}</h2>
       <ul v-for="(e, i) in s.entries" :key="e.id" class="flex flex-col gap-3">
         <SearchResultItemLink v-if="i < s.n_visible" :highlighted="false" :item="e" />
@@ -49,15 +60,19 @@ function viewMoreQuery(facet: string) {
 <i18n lang="yaml">
 de:
   sections:
-    sites_buildings: Gebäude / Standorte
+    sites: Standorte
+    buildings: Gebäude
     rooms: Räume
+    pois: POIs
   view_more: mehr anzeigen
   approx_results: ca. {count} Ergebnisse, bitte grenze die Suche weiter ein
   results: 1 Ergebnis | {count} Ergebnisse
 en:
   sections:
-    sites_buildings: Buildings / Sites
+    sites: Sites
+    buildings: Buildings
     rooms: Rooms
+    pois: POIs
   view_more: view more
   approx_results: approx. {count} results, please narrow the search further
   results: 1 result | {count} results

--- a/webclient/app/composables/autocomplete.ts
+++ b/webclient/app/composables/autocomplete.ts
@@ -1,7 +1,6 @@
 import type { components } from "~/api_types";
 
 type SearchResponse = components["schemas"]["SearchResponse"];
-type ResultEntry = components["schemas"]["ResultEntry"];
 
 function _allowHighlighting(text: string): string {
   /// This function does still parse content only from our internal API (which should not try to pawn us in the
@@ -11,15 +10,8 @@ function _allowHighlighting(text: string): string {
   return opt.replaceAll("\x19", "<b class='text-blue-500'>").replaceAll("\x17", "</b>");
 }
 
-export type SectionFacet = RoomFacet | SiteBuildingFacet;
-type RoomFacet = {
-  facet: "rooms";
-  name: string;
-  entries: EntryFacet[];
-  estimatedTotalHits: number;
-};
-type SiteBuildingFacet = {
-  facet: "sites_buildings";
+export type SectionFacet = {
+  facet: "sites" | "buildings" | "rooms" | "pois";
   name: string;
   entries: EntryFacet[];
   estimatedTotalHits: number;
@@ -35,51 +27,37 @@ type EntryFacet = {
   parsed_id: string | null;
 };
 
-export function extractFacets(data: SearchResponse, roomName: string, buildingName: string) {
+export function extractFacets(
+  data: SearchResponse,
+  labels: Record<SectionFacet["facet"], string>
+): SectionFacet[] {
   const sections: SectionFacet[] = [];
 
   for (const section of data.sections) {
-    const entries: EntryFacet[] = [];
-
-    switch (section.facet) {
-      case "rooms":
-        for (const entry of section.entries) {
-          entries.push({
-            id: entry.id,
-            name: _allowHighlighting(entry.name), // we explicitly dont let vue sanitise this text
-            type: entry.type,
-            subtext: entry.subtext,
-            subtext_bold: _allowHighlighting(entry.subtext_bold || ""), // we explicitly dont let vue sanitise this text
-            parsed_id: _allowHighlighting(entry.parsed_id || ""), // we explicitly dont let vue sanitise this text
-          });
-        }
-        sections.push({
-          facet: "rooms",
-          name: roomName,
-          entries: entries,
-          estimatedTotalHits: section.estimatedTotalHits,
-        });
-        break;
-      case "sites_buildings":
-        for (const entry of section.entries) {
-          entries.push({
-            id: entry.id,
-            name: _allowHighlighting(entry.name), // we explicitly dont let vue sanitise this text
-            type: entry.type,
-            subtext: entry.subtext,
-            subtext_bold: null,
-            parsed_id: null,
-          });
-        }
-        sections.push({
-          facet: "sites_buildings",
-          name: buildingName,
-          expanded: false,
-          entries: entries,
-          estimatedTotalHits: section.estimatedTotalHits,
-          n_visible: section.n_visible || entries.length,
-        });
+    if (
+      section.facet !== "sites" &&
+      section.facet !== "buildings" &&
+      section.facet !== "rooms" &&
+      section.facet !== "pois"
+    ) {
+      continue;
     }
+    const entries: EntryFacet[] = section.entries.map((entry) => ({
+      id: entry.id,
+      name: _allowHighlighting(entry.name),
+      type: entry.type,
+      subtext: entry.subtext,
+      subtext_bold: _allowHighlighting(entry.subtext_bold || ""),
+      parsed_id: _allowHighlighting(entry.parsed_id || ""),
+    }));
+    sections.push({
+      facet: section.facet,
+      name: labels[section.facet],
+      entries,
+      estimatedTotalHits: section.estimatedTotalHits,
+      expanded: false,
+      n_visible: section.n_visible || entries.length,
+    });
   }
 
   return sections;

--- a/webclient/app/composables/searchFilters.ts
+++ b/webclient/app/composables/searchFilters.ts
@@ -4,31 +4,12 @@ import { allValues, firstOrDefault } from "~/composables/common";
 type FilterKind = "in" | "usage" | "type" | "near";
 type ListKind = "in" | "usage" | "type";
 
-// User-facing type buckets map to the underlying meilisearch `type` values.
-// Buckets bundle types that users wouldn't distinguish (e.g. virtual_room
-// is just a building part — users don't know the difference from a room).
-export const TYPE_BUCKETS = {
-  room: ["room", "virtual_room"],
-  building: ["building", "joined_building"],
-  site: ["site", "campus", "area"],
-  poi: ["poi"],
-} as const satisfies Record<string, readonly string[]>;
-
-export type TypeBucket = keyof typeof TYPE_BUCKETS;
-export const TYPE_BUCKET_OPTIONS = Object.keys(TYPE_BUCKETS) as readonly TypeBucket[];
-
-function isTypeBucket(value: string): value is TypeBucket {
-  return value in TYPE_BUCKETS;
-}
-
-function expandTypes(values: readonly string[]): string[] {
-  const out: string[] = [];
-  for (const v of values) {
-    if (isTypeBucket(v)) out.push(...TYPE_BUCKETS[v]);
-    else out.push(v); // pass through unknown values verbatim
-  }
-  return out;
-}
+// The backend's `facet` field already buckets indexed types into these four
+// categories; the frontend uses them directly as the user-facing taxonomy.
+// Subtypes (`virtual_room`, `joined_building`, `campus`, `area`) are an
+// internal detail of the data pipeline and not surfaced to users.
+export const FACET_OPTIONS = ["site", "building", "room", "poi"] as const;
+export type Facet = (typeof FACET_OPTIONS)[number];
 
 export type SearchFilters = {
   inFilter: Readonly<Ref<readonly string[]>> | ComputedRef<readonly string[]>;
@@ -90,7 +71,7 @@ function makeShared(values: {
   function appendToParams(params: URLSearchParams) {
     for (const v of values.inFilter.value) params.append("in", v);
     for (const v of values.usageFilter.value) params.append("usage", v);
-    for (const v of expandTypes(values.typeFilter.value)) params.append("type", v);
+    for (const v of values.typeFilter.value) params.append("type", v);
     if (values.nearFilter.value) params.append("near", values.nearFilter.value);
   }
 

--- a/webclient/app/pages/search.vue
+++ b/webclient/app/pages/search.vue
@@ -13,18 +13,32 @@ const feedback = useFeedback();
 const filters = useSearchFilters();
 
 const query_q = computed<string>(() => firstOrDefault(route.query.q, ""));
+const query_limit_sites = computed<number>(() =>
+  Number.parseInt(firstOrDefault(route.query.limit_sites, "10"), 10)
+);
 const query_limit_buildings = computed<number>(() =>
   Number.parseInt(firstOrDefault(route.query.limit_buildings, "10"), 10)
 );
 const query_limit_rooms = computed<number>(() =>
   Number.parseInt(firstOrDefault(route.query.limit_rooms, "50"), 10)
 );
-const query_limit_all = computed<number>(() => query_limit_rooms.value + query_limit_rooms.value);
+const query_limit_pois = computed<number>(() =>
+  Number.parseInt(firstOrDefault(route.query.limit_pois, "10"), 10)
+);
+const query_limit_all = computed<number>(
+  () =>
+    query_limit_sites.value +
+    query_limit_buildings.value +
+    query_limit_rooms.value +
+    query_limit_pois.value
+);
 const apiUrl = computed(() => {
   const params = new URLSearchParams();
   params.append("q", query_q.value);
+  params.append("limit_sites", query_limit_sites.value.toString());
   params.append("limit_buildings", query_limit_buildings.value.toString());
   params.append("limit_rooms", query_limit_rooms.value.toString());
+  params.append("limit_pois", query_limit_pois.value.toString());
   params.append("limit_all", query_limit_all.value.toString());
   params.append("lang", locale.value);
   params.append("pre_highlight", "<b class='text-blue'>");
@@ -45,20 +59,17 @@ const description = computed(() => {
   let estimatedTotalHits = 0;
   for (const section of data.value.sections) {
     if (section.estimatedTotalHits) {
-      let facetStr = t("sections.rooms");
-      if (section.facet === "sites_buildings") {
-        facetStr = t("sections.buildings");
-        if (section.estimatedTotalHits !== section.n_visible) {
-          const visibleStr = t("sections.of_which_visible");
-          facetStr = `(${section.n_visible} ${visibleStr}) ${facetStr}`;
-        }
+      let facetStr = t(`sections.${section.facet}`);
+      if (section.estimatedTotalHits !== section.n_visible) {
+        const visibleStr = t("sections.of_which_visible");
+        facetStr = `(${section.n_visible} ${visibleStr}) ${facetStr}`;
       }
       if (estimatedTotalHits > 0) sectionsDescr += t("sections.and");
       sectionsDescr += `${section.estimatedTotalHits} ${facetStr}`;
     }
     estimatedTotalHits += section.estimatedTotalHits;
   }
-  if (estimatedTotalHits === 0) sectionsDescr = t("sections.no_buildings_rooms_found");
+  if (estimatedTotalHits === 0) sectionsDescr = t("sections.nothing_found");
   else sectionsDescr += t("sections.were_found");
   return sectionsDescr;
 });
@@ -106,8 +117,10 @@ useSeoMeta({
     <ClientOnly>
       <SearchSectionList
         :data="data"
+        :query-limit-sites="query_limit_sites"
         :query-limit-buildings="query_limit_buildings"
         :query-limit-rooms="query_limit_rooms"
+        :query-limit-pois="query_limit_pois"
       />
     </ClientOnly>
   </div>
@@ -116,10 +129,13 @@ useSeoMeta({
 <i18n lang="yaml">
 de:
   sections:
-    buildings: Gebäude / Standorte
+    sites: Standorte
+    buildings: Gebäude
     rooms: Räume
+    pois: POIs
+    addresses: Adressen
     and: und
-    no_buildings_rooms_found: Keine Gebäude / Standorte oder Räume konnten gefunden werden.
+    nothing_found: Es konnten keine Ergebnisse gefunden werden.
     of_which_visible: davon sichtbar
     were_found: wurden gefunden.
   feedback:
@@ -129,10 +145,13 @@ de:
   search_for: Suche nach
 en:
   sections:
-    buildings: Buildings / Sites
+    sites: Sites
+    buildings: Buildings
     rooms: Rooms
+    pois: POIs
+    addresses: Addresses
     and: and
-    no_buildings_rooms_found: No buildings / locations or rooms could be found.
+    nothing_found: No results could be found.
     of_which_visible: of them visible
     were_found: were found.
   feedback:


### PR DESCRIPTION
## Summary

Stacks on top of #2908. Where #2908 funneled POIs into the existing `room` facet as a tactical fix, this PR aligns the backend, API, and frontend on **four first-class facets** — `site`, `building`, `room`, `poi` — and splits POIs out into their own section. It also fixes a side bug where `site`-faceted documents were loaded into Meilisearch but never returned by search (the federation only queried `room` + `building` after #2906).

### Backend
- Federate over 4 facets via a `FACETS` list rather than 2 hand-written queries.
- `ResultFacet` enum: `SitesBuildings` → `Sites` + `Buildings`, add `Pois`.
- Merger matches on the `facet` field (now part of `MSHit`) instead of `type`. Drops the `"campus" | "site" | "area"` dead arm and the `"poi"` workaround that #2908 added to the rooms arm. Generalized n_visible-freeze logic for sites > buildings > rooms > pois priority.
- `Limits` adds `sites_count` + `pois_count`; new `limit_sites` and `limit_pois` query params.
- `?type=` query param now filters by *facet* (`site|building|room|poi`); values outside that allowlist are silently dropped (previously the frontend expanded `site` into raw `type` values like `campus`/`virtual_room`).

### Frontend
- Drop `TYPE_BUCKETS` / `expandTypes`. The backend's `facet` field already buckets subtypes (`virtual_room`, `joined_building`, `campus`, `area`); the frontend doesn't need to mirror that. Replaced by `FACET_OPTIONS`.
- `SearchSectionList` now renders up to 4 sections; `viewMoreQuery` bumps only the facet whose "view more" was clicked.
- `App/NavigationSearchBar`: per-facet `expandedFacets` set replaces the `sites_buildings_expanded` boolean. **Side fix**: expanded sections now actually render their hidden entries — the existing button toggled keyboard-nav state but the template still capped rendering at `n_visible`, so the hidden items were never visible.
- `pages/search.vue`: 4 `limit_*` params, generalized description text.

### Data
- `data/processors/export.py`: `"poi": "room"` (#2908) → `"poi": "poi"`.

`api_types/index.ts` + `data/output/openapi.yaml` updated; CI's update-openapi job will regenerate them properly on merge.

## Deploy ordering

Same as #2908 — data CI must rebuild `search_data.json` (so POIs land with `facet: "poi"`) before/with the server redeploy.

## Test plan

- [x] `cargo check --tests`
- [x] `cargo test routes::search::` — 22 unit tests pass
- [x] `cargo insta accept` — 5 snapshots updated to reflect 4-section layout
- [x] `pnpm exec vue-tsc --noEmit` (all four nuxt tsconfigs)
- [x] `pnpm exec biome lint --error-on-warnings` — clean
- [ ] Local data rebuild: `cd data && uv run main.py`, then `jq '[.[] | .facet] | group_by(.) | map({facet: .[0], count: length})' output/search_data.json` — expect non-zero counts for `site`, `building`, `room`, `poi`, no `null`.
- [ ] Local server smoke: `mensa` → `sites`+`buildings` sections; `parabel` → `pois`; `garching&type=site` → only `sites`; `mw&type=poi` → only `pois`.
- [ ] Frontend `pnpm dev`: 4 filter chips, 4 result sections, "view more" bumps the correct `limit_*`, "show hidden" actually expands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)