### PR TITLE
feat(webclient): surface AStA Iris learning-room coverage on detail pages

### DIFF
--- a/webclient/app/components/DetailsContentSidebar.vue
+++ b/webclient/app/components/DetailsContentSidebar.vue
@@ -200,6 +200,7 @@ const suggestLocationFix = () => {
         id="details-no_floor_overlay"
       />
       <Toast v-if="data.props.comment" :msg="data.props.comment" id="details-comment"/>
+      <DetailsIrisCoverageCard :has-coverage="data.props.has_iris_coverage"/>
     </div>
 
     <!-- Property Table -->

--- a/webclient/app/components/DetailsIrisCoverageCard.vue
+++ b/webclient/app/components/DetailsIrisCoverageCard.vue
@@ -1,0 +1,47 @@
+<script setup lang="ts">
+import { mdiBookOpenPageVariantOutline, mdiOpenInNew } from "@mdi/js";
+
+const props = defineProps<{
+  // Absent (rather than `false`) for entries without coverage, so an undefined value
+  // must render nothing rather than an empty state.
+  readonly hasCoverage?: boolean;
+}>();
+
+const { t } = useI18n({ useScope: "local" });
+
+const IRIS_URL = "https://iris.asta.tum.de/";
+</script>
+
+<template>
+  <div
+    v-if="props.hasCoverage"
+    class="text-blue-900 dark:text-blue-50 bg-blue-50 dark:bg-blue-900 border border-blue-200 dark:border-blue-700 rounded p-3 text-sm flex flex-row gap-3 print:!hidden"
+  >
+    <MdiIcon :path="mdiBookOpenPageVariantOutline" :size="20" class="mt-0.5 shrink-0" aria-hidden="true" />
+    <div class="flex flex-col items-start gap-2">
+      <div class="flex flex-col gap-0.5">
+        <span class="font-semibold">{{ t("title") }}</span>
+        <span>{{ t("description") }}</span>
+      </div>
+      <Btn
+        :to="IRIS_URL"
+        variant="link"
+        size="text-sm gap-1.5 rounded font-semibold"
+      >
+        {{ t("cta") }}
+        <MdiIcon :path="mdiOpenInNew" :size="16" class="my-auto" aria-hidden="true" />
+      </Btn>
+    </div>
+  </div>
+</template>
+
+<i18n lang="yaml">
+de:
+  title: Auf der Suche nach einem Lernplatz?
+  description: AStA Iris zeigt, welche Lernräume in diesem Gebäude gerade frei sind.
+  cta: Freien Lernraum finden
+en:
+  title: Looking for a place to study?
+  description: AStA Iris shows which learning rooms in this building are currently free.
+  cta: Find a free learning room
+</i18n>


### PR DESCRIPTION
Stacked on #3109 (`feat/iris-coverage-signal`). Base this PR's review on that branch, not `main` — `props.has_iris_coverage` does not exist on `main` yet.

## What

Consumes the build-time `props.has_iris_coverage` signal that #3109 wired through the API. When it is truthy on a building/area, the entry detail sidebar shows an info-card callout linking out to [AStA Iris](https://iris.asta.tum.de/), so students can find a currently-free learning room in the building.

## Where

- **New** `webclient/app/components/DetailsIrisCoverageCard.vue` — blue info-level callout: book icon, hook title, one-sentence explanation, and an inline external-link CTA ("Find a free learning room"). EN + DE copy in the component's local `<i18n>` block.
- `DetailsContentSidebar.vue` — one line, added to the Toasts/Alerts stack **after** the existing alerts, so attention-warnings (building-level accuracy, missing floor overlay) still come first and this opportunity-callout sits beneath them.

## Absent means "no coverage"

The signal is omitted (rather than `false`) for entries without coverage. The card renders nothing when `hasCoverage` is `undefined` — absent is treated as "no coverage", never as a broken or empty state.

## Copy

Iris does **not** offer booking, so the copy describes it purely as showing which rooms are *currently free* (occupancy, not reservation):

- EN: "AStA Iris shows which learning rooms in this building are currently free."
- DE: "AStA Iris zeigt, welche Lernräume in diesem Gebäude gerade frei sind."

## Notes

- No per-building deep link exists on the signal (it is a plain bool), so the CTA points at the Iris root. If Iris later exposes a per-building URL, the component is the single spot to thread it through.
- `print:!hidden`, since it is an interactive external entry point.
- The signal is build-time-derived for buildings/areas, so the card surfaces anywhere the details sidebar renders a covered entry, including the embed view (which reuses this sidebar).

## Verification

- Biome: clean on both files.
- Type-check: pre-existing unrelated errors only (`zod`/`prom-client` missing from this worktree's `node_modules`, existing implicit-`any`s in `additionSchema.ts`); nothing references the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)